### PR TITLE
Nvidia settings bugfix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,20 +5,19 @@ name: Rust CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
-      - '**.md'
+      - "**.md"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
 env:
   CARGO_TERM_COLOR: always
   RUST_TOOLCHAIN: nightly
   TOOLCHAIN_PROFILE: minimal
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
 
 jobs:
   lints:

--- a/src/mainwindow/imp.rs
+++ b/src/mainwindow/imp.rs
@@ -1860,6 +1860,12 @@ impl WindowImpl for MainWindow {
         // serde_json::to_writer(file, &gpu_data)
         //     .expect("Could not write data to json file");
 
+        // Cancel any under-way sub processes
+        // if let Some(control) = Cancellable::current() {
+        //     println!("Closing open windows..");
+        //     control.cancel();
+        // }
+
         // Store sub-window states in settings
         self.update_setting("app-settings-open", false);
         self.update_setting("nvidia-settings-open", false);

--- a/src/mainwindow/imp.rs
+++ b/src/mainwindow/imp.rs
@@ -28,9 +28,7 @@ use gtk::{
     subclass::prelude::*, Button, CompositeTemplate, PolicyType, ScrolledWindow, Stack,
     TemplateChild,
 };
-use std::{
-    cell::Cell, cell::RefCell, cell::RefMut, rc::Rc
-};
+use std::{cell::Cell, cell::RefCell, cell::RefMut, rc::Rc};
 
 // Modules
 use crate::{

--- a/src/mainwindow/imp.rs
+++ b/src/mainwindow/imp.rs
@@ -1798,6 +1798,10 @@ impl WindowImpl for MainWindow {
      *
      */
     fn close_request(&self, window: &Self::Type) -> Inhibit {
+        /*
+        //NOTE: this was meant for saving to json, probably unecessary now that i'm not using it..
+
+
         // Create vector for final saving
         let mut save_data: Vec<Vec<(String, String)>> = vec![];
         //let mut save_data: gio::ListStore;
@@ -1828,36 +1832,16 @@ impl WindowImpl for MainWindow {
             //save_data.append(&test_s);
         }
 
-        // Create collection to store in json
         // TEST OUTPUT
         for gpu in save_data {
             for stat in gpu {
                 println!("STAT NAME: `{}` STAT VALUE: `{}`", stat.0, stat.1);
             }
         }
-        // let qq = save_data
-        //      .snapshot() //?
-        //      .iter()
-        //      .filter_map(Cast::downcast_ref::<TaskObject>)
-        //      .map(TaskObject::task_data)
-        //      .collect();
+        */
 
-        // let gpu_data: Vec<TaskData> = current_page
-        //     .tasks()    // change to "items" and grab all statistic pairs/objects
-        //     .snapshot() //?
-        //     .iter()
-        //     .filter_map(Cast::downcast_ref::<TaskObject>)
-        //     .map(TaskObject::task_data)
-        //     .collect();
-
-        // Store in json
-        // Create json file object
-        //let file = File::create(data_path()).expect("Could not create json file.");
-
-        // Write json file
-        // serde_json::to_writer(file, &gpu_data)
-        //     .expect("Could not write data to json file");
-
+        //NOTE: This doesn't work for some reason, but seems to be to do with
+        //      nvidia-settings or the Cancellable implementation in the rust bindings..
         // Cancel any under-way sub processes
         // if let Some(control) = Cancellable::current() {
         //     println!("Closing open windows..");

--- a/src/mainwindow/imp.rs
+++ b/src/mainwindow/imp.rs
@@ -21,7 +21,7 @@
 use adwaita::{gio, glib, prelude::*, subclass::prelude::*};
 use gio::Settings;
 use glib::{
-    clone, once_cell::sync::Lazy, once_cell::sync::OnceCell, signal::Inhibit,
+    once_cell::sync::Lazy, once_cell::sync::OnceCell, signal::Inhibit,
     subclass::InitializingObject, FromVariant, ParamSpec, Value,
 };
 use gtk::{
@@ -29,7 +29,7 @@ use gtk::{
     TemplateChild,
 };
 use std::{
-    cell::Cell, cell::RefCell, cell::RefMut, rc::Rc, sync::Arc, sync::Mutex, sync::MutexGuard,
+    cell::Cell, cell::RefCell, cell::RefMut, rc::Rc
 };
 
 // Modules

--- a/src/mainwindow/mod.rs
+++ b/src/mainwindow/mod.rs
@@ -274,57 +274,63 @@ impl MainWindow {
             //let def = shell::Edge::Top;
             //let dd = gio::DesktopAppInfo::from_filename("nvidia-settings.desktop");
 
-            if !app_settings_open {
-                // Grab current stored provider
-                let mut provider: Option<Provider> = window.property("provider");
+            match app_settings_open {
+                false => {
+                    // Grab current stored provider
+                    let mut provider: Option<Provider> = window.property("provider");
 
-                // Check if provider exists
-                match provider {
-                    Some(prov) => {
-                        // Open Nvidia Settings
-                        match prov.open_settings() {
-                            Ok(_result) => {
-                                println!("Opening the Nvidia Settings app..");
-                            },
-                            Err(err) => println!(
-                                "An error occured: {}",
-                                err
-                            ),
-                        }
-                    },
-                    None => {
-                        // Check provider type
-                        let provider_type: i32 = window.imp().get_setting::<i32>("provider");
+                    // Check if provider exists
+                    match provider {
+                        Some(prov) => {
+                            // Open Nvidia Settings
+                            match prov.open_settings() {
+                                Ok(_) => {
+                                    println!("Opening the Nvidia Settings app..");
 
-                        // Create new provider
-                        //println!("Creating new Provider..");//TEST
-                        window.set_property("provider", Some(window.imp().create_provider(provider_type)));
+                                    // Set state in settings
+                                    window.imp().update_setting::<bool>("nvidia-settings-open", true);
+                                },
+                                Err(err) => println!(
+                                    "An error occured: {}",
+                                    err
+                                ),
+                            }
+                        },
+                        None => {
+                            // Check provider type
+                            let provider_type: i32 = window.imp().get_setting::<i32>("provider");
 
-                        // Grab new provider
-                        provider = window.property("provider");
+                            // Create new provider
+                            //println!("Creating new Provider..");//TEST
+                            window.set_property("provider", Some(window.imp().create_provider(provider_type)));
 
-                        // Open Nvidia Settings
-                        println!("Opening the Nvidia Settings app..");//TEST
-                        match provider {
-                            Some(prov) => {
-                                // Open Nvidia Settings
-                                match prov.open_settings() {
-                                    Ok(_result) => {
-                                        println!("Opening the Nvidia Settings app..");
-                                    },
-                                    Err(err) => println!(
-                                        "An error occured: {}",
-                                        err
-                                    ),
-                                }
-                            },
-                            None => panic!("Cannot find `Provider`!")
+                            // Grab new provider
+                            provider = window.property("provider");
+
+                            // Open Nvidia Settings
+                            println!("Opening the Nvidia Settings app..");//TEST
+                            match provider {
+                                Some(prov) => {
+                                    // Open Nvidia Settings
+                                    match prov.open_settings() {
+                                        Ok(_) => {
+                                            println!("Opening the Nvidia Settings app..");
+
+                                            // Set state in settings
+                                            window.imp().update_setting::<bool>("nvidia-settings-open", true);
+                                        },
+                                        Err(err) => println!(
+                                            "An error occured: {}",
+                                            err
+                                        ),
+                                    }
+                                },
+                                None => panic!("Cannot find `Provider`!")
+                            }
                         }
                     }
                 }
-
-                // Set state in settings
-                window.imp().update_setting::<bool>("nvidia-settings-open", true);
+                true => println!("Nvidia Settings app already open!"),
             }
         }));
         self.add_action(&open_nvidia_settings);

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -27,7 +27,7 @@ use gtk::{gio, glib, prelude::ObjectExt};
 use std::ffi::OsStr;
 
 // Crates
-use crate::subprocess::subprocess::exec_communicate;
+use crate::subprocess::subprocess::exec_communicate_sync;
 
 // GObject wrapper for Processor
 glib::wrapper! {
@@ -194,14 +194,14 @@ impl Processor {
                 ];
 
                 // Run process, get output
-                match exec_communicate(&argv, None::<&gio::Cancellable>) {
+                match exec_communicate_sync(&argv, None::<&gio::Cancellable>) {
                     Ok(return_val) => match return_val {
                         // ACTUAL
                         (None, None) => return Ok(None),
 
                         (None, Some(stderr_buffer)) => {
                             println!(
-                                "Process failed with error: {}",
+                                "Process failed with error: `{}`",
                                 String::from_utf8_lossy(&stderr_buffer)
                             );
                         }
@@ -212,7 +212,7 @@ impl Processor {
 
                         (Some(stdout_buffer), Some(stderr_buffer)) => {
                             println!(
-                                "Process succeeded, but with error: {}",
+                                "Process succeeded, but with error: `{}`",
                                 String::from_utf8_lossy(&stderr_buffer)
                             );
 
@@ -234,14 +234,14 @@ impl Processor {
                 ];
 
                 // Run process, get output
-                match exec_communicate(&argv, None::<&gio::Cancellable>) {
+                match exec_communicate_sync(&argv, None::<&gio::Cancellable>) {
                     Ok(return_val) => match return_val {
                         // ACTUAL
                         (None, None) => return Ok(None),
 
                         (None, Some(stderr_buffer)) => {
                             println!(
-                                "Process failed with error: {}",
+                                "Process failed with error: `{}`",
                                 String::from_utf8_lossy(&stderr_buffer)
                             );
                         }
@@ -252,7 +252,7 @@ impl Processor {
 
                         (Some(stdout_buffer), Some(stderr_buffer)) => {
                             println!(
-                                "Process failed with error: {}",
+                                "Process failed with error: `{}`",
                                 String::from_utf8_lossy(&stderr_buffer)
                             );
 
@@ -273,14 +273,14 @@ impl Processor {
                 ];
 
                 // Run process, get output
-                match exec_communicate(&argv, None::<&gio::Cancellable>) {
+                match exec_communicate_sync(&argv, None::<&gio::Cancellable>) {
                     Ok(return_val) => match return_val {
                         // ACTUAL
                         (None, None) => return Ok(None),
 
                         (None, Some(stderr_buffer)) => {
                             println!(
-                                "Process failed with error: {}",
+                                "Process failed with error: `{}`",
                                 String::from_utf8_lossy(&stderr_buffer)
                             );
                         }
@@ -291,7 +291,7 @@ impl Processor {
 
                         (Some(stdout_buffer), Some(stderr_buffer)) => {
                             println!(
-                                "Process failed with error: {}",
+                                "Process failed with error: `{}`",
                                 String::from_utf8_lossy(&stderr_buffer)
                             );
 
@@ -311,14 +311,14 @@ impl Processor {
                 ];
 
                 // Run process, get output
-                match exec_communicate(&argv, None::<&gio::Cancellable>) {
+                match exec_communicate_sync(&argv, None::<&gio::Cancellable>) {
                     Ok(return_val) => match return_val {
                         // ACTUAL
                         (None, None) => return Ok(None),
 
                         (None, Some(stderr_buffer)) => {
                             println!(
-                                "Process failed with error: {}",
+                                "Process failed with error: `{}`",
                                 String::from_utf8_lossy(&stderr_buffer)
                             );
                         }
@@ -329,7 +329,7 @@ impl Processor {
 
                         (Some(stdout_buffer), Some(stderr_buffer)) => {
                             println!(
-                                "Process failed with error: {}",
+                                "Process failed with error: `{}`",
                                 String::from_utf8_lossy(&stderr_buffer)
                             );
 
@@ -345,14 +345,14 @@ impl Processor {
                 let argv: [&OsStr; 2] = [call_stack_items[0], call_stack_items[1]];
 
                 // Run process, get output
-                match exec_communicate(&argv, None::<&gio::Cancellable>) {
+                match exec_communicate_sync(&argv, None::<&gio::Cancellable>) {
                     Ok(return_val) => match return_val {
                         // ACTUAL
                         (None, None) => return Ok(None),
 
                         (None, Some(stderr_buffer)) => {
                             println!(
-                                "Process failed with error: {}",
+                                "Process failed with error: `{}`",
                                 String::from_utf8_lossy(&stderr_buffer)
                             );
                         }
@@ -363,7 +363,7 @@ impl Processor {
 
                         (Some(stdout_buffer), Some(stderr_buffer)) => {
                             println!(
-                                "Process failed with error: {}",
+                                "Process failed with error: `{}`",
                                 String::from_utf8_lossy(&stderr_buffer)
                             );
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -310,6 +310,8 @@ impl Provider {
         match self.property::<i32>("provider-type") {
             // Open Nvidia Settings
             0 | 1 => {
+                //NOTE: This doesn't work for some reason, but seems to be to do with
+                //      nvidia-settings or the Cancellable implementation in the rust bindings..
                 // Add new cancellable object to stack
                 //let control: Cancellable = Cancellable::new();
                 //control.push_current();

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -22,7 +22,7 @@ mod imp;
 
 // Imports
 use adwaita::{gio, glib};
-use gio::Settings;
+use gio::{Settings, Cancellable};
 use glib::Object;
 use gtk::{prelude::*, subclass::prelude::*};
 use std::ffi::OsStr;
@@ -307,7 +307,12 @@ impl Provider {
         match self.property::<i32>("provider-type") {
             // Open Nvidia Settings
             0 | 1 => {
-                match exec_communicate_async(&[OsStr::new("nvidia-settings")], None::<&gio::Cancellable>, |result| {
+                // Add new cancellable object to stack
+                //let control: Cancellable = Cancellable::new();
+                //control.push_current();
+
+                // Start cancellable async process
+                match exec_communicate_async(&[OsStr::new("nvidia-settings")], None::<&Cancellable>/*Some(&control)*/, |result| {
                     // Callback
                     match result {
                         Err(err) => {

--- a/src/subprocess/mod.rs
+++ b/src/subprocess/mod.rs
@@ -125,7 +125,7 @@ pub mod subprocess {
         argv: &[&OsStr],
         cancellable: Option<&impl IsA<gio::Cancellable>>,
         // Callback? that way could modify settings....
-        callback: Q //dyn FnOnce(Result<(Option<glib::Bytes>, Option<glib::Bytes>), glib::Error>) + 'static
+        callback: Q, //dyn FnOnce(Result<(Option<glib::Bytes>, Option<glib::Bytes>), glib::Error>) + 'static
     ) -> Result<(), glib::Error> {
         // Create subprocess
         match gio::Subprocess::newv(argv, gio::SubprocessFlags::STDOUT_PIPE) {

--- a/src/subprocess/mod.rs
+++ b/src/subprocess/mod.rs
@@ -25,7 +25,7 @@ pub mod subprocess {
 
     /**
      * Name:
-     * execCheck
+     * exec_check_async
      *
      * Description:
      * Execute a command asynchronously and check the exit status
@@ -43,7 +43,7 @@ pub mod subprocess {
      * Notes:
      *
      */
-    pub fn exec_check(
+    pub fn exec_check_async(
         argv: &[&OsStr],
         cancellable: Option<&impl IsA<gio::Cancellable>>,
     ) -> Result<(), glib::Error> {
@@ -59,7 +59,7 @@ pub mod subprocess {
 
     /**
      * Name:
-     * exec_communicate
+     * exec_communicate_sync
      *
      * Description:
      * Execute a command and return any output
@@ -77,7 +77,7 @@ pub mod subprocess {
      * Notes:
      *
      */
-    pub fn exec_communicate(
+    pub fn exec_communicate_sync(
         argv: &[&OsStr],
         cancellable: Option<&impl IsA<gio::Cancellable>>,
     ) -> Result<(Option<Bytes>, Option<Bytes>), glib::Error> {
@@ -96,6 +96,46 @@ pub mod subprocess {
                     }
                 },
             },
+        }
+    }
+
+    /**
+     * Name:
+     * exec_communicate
+     *
+     * Description:
+     * Execute a command asynchronously and check the exit status
+     *
+     * If given, @cancellable can be used to stop the process before it finishes.
+     *
+     * <https://gtk-rs.org/gtk-rs-core/stable/0.14/docs/src/gio/auto/subprocess.rs.html>
+     *
+     * Made:
+     * 27/11/2022
+     *
+     * Made by:
+     * Deren Vural
+     *
+     * Notes:
+     *
+     */
+    pub fn exec_communicate_async<
+        Q: FnOnce(Result<(Option<glib::Bytes>, Option<glib::Bytes>), glib::Error>) + Send + 'static,
+    >(
+        argv: &[&OsStr],
+        cancellable: Option<&impl IsA<gio::Cancellable>>,
+        // Callback? that way could modify settings....
+        callback: Q //dyn FnOnce(Result<(Option<glib::Bytes>, Option<glib::Bytes>), glib::Error>) + 'static
+    ) -> Result<(), glib::Error> {
+        // Create subprocess
+        match gio::Subprocess::newv(argv, gio::SubprocessFlags::STDOUT_PIPE) {
+            Err(err) => Err(err),
+            // Run subprocess
+            Ok(proc) => {
+                proc.communicate_async(None, cancellable, callback);
+
+                Ok(())
+            }
         }
     }
 }

--- a/style.css
+++ b/style.css
@@ -10,7 +10,7 @@ spinbutton {
 }
 
 grid#statistic_item_grid {
-	outline-style: solid;
-	outline-width: 1px;
-	border-radius: 3px;
+  outline-style: solid;
+  outline-width: 1px;
+  border-radius: 3px;
 }


### PR DESCRIPTION
Fixed to only let one nvidia-settings process be created each run of the app - only problem being that nvidia-settings doesn't seem to respect the call to cancel (either that or i've misunderstood the concept..)

closes #26 


also a bunch of trunk formatting