### PR TITLE
Reload on settings exit

### DIFF
--- a/src/gpu_page/imp.rs
+++ b/src/gpu_page/imp.rs
@@ -24,9 +24,10 @@ use gio::Settings;
 use glib::{
     once_cell::sync::Lazy, once_cell::sync::OnceCell, subclass::InitializingObject,
     subclass::Signal, subclass::SignalType, FromVariant, ParamSpec, ToValue, Value,
+    translate::FromGlib, SourceId
 };
-use gtk::{subclass::prelude::*, CompositeTemplate, TemplateChild};
-use std::{cell::Cell, cell::RefCell, rc::Rc};
+use gtk::{subclass::prelude::*, CompositeTemplate, TemplateChild, Label, Grid, Orientation, LayoutChild, Align};
+use std::{cell::Cell, cell::RefCell, rc::Rc, sync::Arc, sync::Mutex, sync::MutexGuard};
 
 // Modules
 use crate::{modificationwindow::ModificationWindow, provider::Provider};
@@ -163,6 +164,396 @@ impl GpuPage {
      */
     pub fn replace_stack(&self, stack: Option<&ViewStack>) {
         self.view_switcher.set_stack(stack);
+    }
+
+    /**
+     * Name:
+     * create_properties
+     *
+     * Description:
+     * Add labels (of properties) to a passed grid, returns the grid afterwards
+     *
+     * Made:
+     * 03/12/2022
+     *
+     * Made by:
+     * Deren Vural
+     *
+     * Notes:
+     *
+     */
+    pub fn create_properties(
+        &self,
+        grid: Grid,
+        properties: Vec<String>,
+        mut labels: Vec<Label>,
+    ) -> (Grid, Vec<Label>) {
+        // Load properties from struct
+        let properties_store: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(properties));
+
+        // Grab grid manager
+        let grid_manager = grid.layout_manager().unwrap();
+
+        // For each Property
+        for property in Arc::clone(&properties_store).lock().unwrap().iter() {
+            // println!("BUILDING PROPERTY LABEL: `{}`", property); //TEST
+
+            //==BUILD==
+            // Build grid for 2 labels and attach to this page
+            let new_grid_name: String = String::from("property_item_grid");
+            let new_grid: Grid = Grid::builder()
+                .name(&new_grid_name)
+                .orientation(Orientation::Horizontal)
+                //.margin_start(12)
+                //.margin_end(12)
+                //.margin_top(12)
+                //.margin_bottom(12)
+                //.halign(Align::Start)
+                //.valign(Align::Center)
+                //.hexpand(true)
+                //.vexpand(true)
+                .build();
+            grid.attach(&new_grid, 0, labels.len() as i32, 100, 12);
+
+            // Set layout properties of grid
+            let child_manager: LayoutChild = grid_manager.layout_child(&new_grid);
+            child_manager.set_property("row-span", 1);
+            child_manager.set_property("column-span", 1);
+            //child_manager.set_property("outline-style", "solid");
+            //child_manager.set_property("outline-width", 1);
+            //child_manager.set_property("border-radius", 3);
+
+            // Fetch layout manager for this (grid) child
+            match new_grid.layout_manager() {
+                Some(internal_grid_manager) => {
+                    // Decide on title label size
+                    let space: i32;
+                    let pretty_label: &str;
+                    //TODO: Update to use global list
+                    match property.to_owned().as_str() {
+                        "util" => {
+                            pretty_label = "GPU Utilization";
+                            space = 5
+                        }
+                        "mem_ctrl_util" => {
+                            pretty_label = "Memory Controller Utilization";
+                            space = 5
+                        }
+                        "encoder_util" => {
+                            pretty_label = "Encoder Utilization";
+                            space = 5
+                        }
+                        "decoder_util" => {
+                            pretty_label = "Decoder Utilization";
+                            space = 5
+                        }
+                        "fan_speed" => {
+                            pretty_label = "Fan Speed";
+                            space = 5
+                        }
+                        "temp" => {
+                            pretty_label = "Temperature";
+                            space = 5
+                        }
+                        "memory_usage" => {
+                            pretty_label = "Memory Usage";
+                            space = 8
+                        }
+                        "memory_total" => {
+                            pretty_label = "Memory Total";
+                            space = 8
+                        }
+                        "power_usage" => {
+                            pretty_label = "Power Usage";
+                            space = 8
+                        }
+                        "none" => {
+                            pretty_label = "None";
+                            space = 5
+                        }
+                        _ => {
+                            pretty_label = property;
+                            space = 5
+                        }
+                    }
+
+                    // Build title label & add to grid
+                    let new_title: String = String::from(property.to_owned()) + "_label";
+                    let new_title_label: Label = Label::builder()
+                        .label(pretty_label)
+                        .name(&new_title)
+                        .hexpand(true)
+                        .hexpand_set(true)
+                        //.halign(Align::Center)
+                        .halign(Align::Start)
+                        //.valign(Align::Center)
+                        .margin_top(12)
+                        .margin_bottom(12)
+                        .width_chars(space)
+                        .build();
+                    new_grid.attach(&new_title_label, 0, 0, 1, 1);
+
+                    // Set layout properties of (title label) child
+                    let title_manager: LayoutChild =
+                        internal_grid_manager.layout_child(&new_title_label);
+                    title_manager.set_property("row-span", 1);
+                    title_manager.set_property("column-span", 1);
+
+                    // Decide on content label size
+                    let space: i32;
+                    match property.to_owned().as_str() {
+                        "util" | "fan_speed" | "temp" | "none" => space = 5,
+                        "memory_usage" | "memory_total" => space = 8,
+                        _ => space = 5,
+                    }
+
+                    // Build content label & add to grid
+                    let new_content: String = String::from(property.to_owned());
+                    let new_content_label: Label = Label::builder()
+                        .label("")
+                        .name(&new_content)
+                        .halign(Align::End)
+                        //.valign(Align::Center)
+                        .width_chars(space)
+                        .build();
+                    new_grid.attach(&new_content_label, 1, 0, 1, 1);
+
+                    // Set layout properties of (content label) child
+                    let content_manager: LayoutChild =
+                        internal_grid_manager.layout_child(&new_content_label);
+                    content_manager.set_property("row-span", 1);
+                    title_manager.set_property("column-span", 1);
+
+                    // Add to list of content labels, for updating in closure (see below)
+                    labels.push(new_content_label);
+                }
+                None => panic!("Cannot find layout manager.."),
+            }
+        }
+
+        // for lab in &labels {
+        //     println!("LABEL: `{}`", lab.widget_name());
+        // }
+
+        // Return modified grid object
+        (grid, labels)
+    }
+
+    /**
+     * Name:
+     * create_updater
+     *
+     * Description:
+     * Creates a recurring closure to fill the passed list of labels
+     * Stores the ID of the recurring closure to allow removal
+     *
+     * Made:
+     * 04/12/2022
+     *
+     * Made by:
+     * Deren Vural
+     *
+     * Notes:
+     * <https://stackoverflow.com/questions/70986004/gtk-rs-set-label-within-glibtimeout-add>
+     * <https://doc.rust-lang.org/rust-by-example/fn/closures/input_parameters.html>
+     *
+     * !!UNSAFE CODE HERE!!
+     */
+    pub fn create_updater(&self, labels: Vec<Label>, properties: Vec<String>) {
+        // !!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!
+        // Check for any running recurring closures
+        // Get stored ID
+        let id_raw: u32 = self.refreshid.clone().get();
+        unsafe {
+            // If the stored ID is valid
+            if id_raw != 0 {
+                // Re-translate to SourceId object
+                let id: SourceId = FromGlib::from_glib(id_raw);
+
+                // Remove recurring closure
+                id.remove();
+
+                // println!("REMOVED RECURRING CLOSURE.."); //TEST
+            } else {
+                // println!("NO PRE-EXISTING RECURRING CLOSURE.."); //TEST
+            }
+        }
+        // !!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!
+
+        // Get stored UUID
+        let uuid: String = self.uuid.clone().get().expect("`uuid` wasn't set properly..").to_string();
+
+        // Load refresh time (s) from settings
+        let refresh_rate: u32 = self.get_setting::<i32>("refreshrate") as u32;
+
+        // Create thread safe container for properties
+        let properties_store: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(properties));
+
+        // Create thread safe container for labels
+        let label_store: Arc<Mutex<Vec<Label>>> = Arc::new(Mutex::new(labels));
+
+        // Create thread safe container for uuid, needed for processor
+        let uuid_store: Arc<Mutex<String>> = Arc::new(Mutex::new(uuid));
+
+        // Create thread safe container for provider
+        let provider: Option<Provider> = self.provider.clone().get().expect("`provider` wasn't set properly..").to_owned();
+        let provider_store: Arc<Mutex<Option<Provider>>> =
+            Arc::new(Mutex::new(provider));
+
+        // Async fill the labels
+        let id: SourceId = glib::timeout_add_seconds_local(refresh_rate, move || {
+            // Grab locked data
+            // list of Properties
+            let properties_lock: Arc<Mutex<Vec<String>>> = Arc::clone(&properties_store);
+            let properties: MutexGuard<Vec<String>> = properties_lock.lock().unwrap();
+            // uuid
+            let uuid_lock: Arc<Mutex<String>> = Arc::clone(&uuid_store);
+            let uuid: String = uuid_lock.lock().unwrap().as_str().to_owned();
+            // current provider for scanning gpu data
+            let provider_lock: Arc<Mutex<Option<Provider>>> = Arc::clone(&provider_store);
+            let mut provider_container: MutexGuard<Option<Provider>> =
+                provider_lock.lock().unwrap();
+
+            let labels_lock: Arc<Mutex<Vec<Label>>> = Arc::clone(&label_store);
+            let labels_container: MutexGuard<Vec<Label>> = labels_lock.lock().unwrap();
+            // println!("labels: `{}`", labels_container.len());
+
+            // For each Property
+            match &mut *provider_container {
+                Some(current_provider) => {
+                    for property in properties.iter() {
+                        // println!("property: `{}`", property); //TEST
+
+                        if property == "none" {
+                            // Check if correct label
+                            for label in labels_container.iter() {
+                                if *property.to_owned() == label.widget_name() {
+                                    label.set_label("N/A");
+                                    // no break here - could be duplicates
+                                }
+                            }
+                        } else {
+                            // Grab current Property from provider
+                            match current_provider.get_gpu_data(&uuid, property) {
+                                Ok(property_value) => {
+                                    // For each output label of the page
+                                    for label in labels_container.iter() {
+                                        // println!("COMPARING AGAINST 1: `{}`", property);
+                                        // println!("COMPARING AGAINST 2: `{}`", label.widget_name());
+
+                                        // Check if correct label
+                                        if *property.to_owned() == label.widget_name() {
+                                            label.set_label(&property_value);
+                                            // no break here - could be duplicates
+                                        }
+                                    }
+                                }
+                                Err(err) => {
+                                    println!("panicked when fetching gpu data: `{}`", err);
+                                    return Continue(false);
+                                }
+                            }
+                        }
+                    }
+                }
+                None => {
+                    println!("panicked when fetching current provider..");
+                    return Continue(false);
+                }
+            }
+
+            Continue(true)
+        });
+
+        // !!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!
+        // Save ID of recurring closure
+        unsafe {
+            self.refreshid.set(id.as_raw());
+        }
+        // !!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!
+    }
+
+    /**
+     * Name:
+     * check_properties_for_view
+     *
+     * Description:
+     * Using passed view title, returns list of saved properties
+     *
+     * Made:
+     * 03/12/2022
+     *
+     * Made by:
+     * Deren Vural
+     *
+     * Notes:
+     *
+     */
+    pub fn check_properties_for_view(&self, view_name: &str) -> Vec<String> {
+        // Load list of Properties for current Page
+        let loaded_properties_data: Vec<String> =
+            self.get_setting::<Vec<String>>("viewcomponentconfigs");
+        // println!("items saved #: `{}`", loaded_properties_data.len()); //TEST
+        // println!("items saved: `{:?}`", loaded_properties_data); //TEST
+
+        // Get stored UUID
+        let uuid: String = self.uuid.clone().get().expect("`uuid` wasn't set properly..").to_string();
+
+        // If present in saved settings, use! otherwise follow below defaults
+        if let 0 = loaded_properties_data.len() {
+            // println!("no properties.."); //TEST
+
+            vec![]
+        } else {
+            // Create temporary structure for sorting loaded data
+            let mut loaded_properties: Vec<String> =
+                vec![String::from(""); loaded_properties_data.len()];
+
+            for index in 0..loaded_properties_data.len() {
+                // println!("item: `{}`", loaded_properties_data[index]); //TEST
+
+                // Split current item into the 4 parts
+                let parts: Vec<&str> = loaded_properties_data[index]
+                    .split(':')
+                    .collect::<Vec<&str>>();
+
+                // Catch any malformed items
+                if parts.len() != 4 {
+                    panic!("Malformed gschema data..");
+                }
+
+                // If from valid page
+                if parts[0] == uuid {
+                    // println!("VALID UUID"); //TEST
+
+                    // If from valid view
+                    if parts[1] == view_name {
+                        // println!("VALID VIEW #"); //TEST
+
+                        // If a valid position
+                        match parts[2].parse::<usize>() {
+                            Ok(position) => {
+                                // println!("POSITION INDEX: `{}`", position); //TEST
+                                if position <= loaded_properties_data.len() {
+                                    // println!("VALID POSITION INDEX"); //TEST
+                                    // println!("VALID PROPERTY: `{}`", parts[3]); //TEST
+
+                                    // Add to final list
+                                    loaded_properties[position] = parts[3].to_owned();
+                                }
+                            }
+                            Err(_) => panic!("Invalid Property position in gschema data.."),
+                        }
+                    }
+                }
+            }
+
+            // Remove any empty properties
+            loaded_properties.retain(|x| *x != "");
+
+            // Return final list
+            loaded_properties.to_owned()
+        }
     }
 }
 

--- a/src/gpu_page/imp.rs
+++ b/src/gpu_page/imp.rs
@@ -23,10 +23,13 @@ use adwaita::{gio, glib, prelude::*, ViewStack, ViewSwitcherBar};
 use gio::Settings;
 use glib::{
     once_cell::sync::Lazy, once_cell::sync::OnceCell, subclass::InitializingObject,
-    subclass::Signal, subclass::SignalType, FromVariant, ParamSpec, ToValue, Value,
-    translate::FromGlib, SourceId
+    subclass::Signal, subclass::SignalType, translate::FromGlib, FromVariant, ParamSpec, SourceId,
+    ToValue, Value,
 };
-use gtk::{subclass::prelude::*, CompositeTemplate, TemplateChild, Label, Grid, Orientation, LayoutChild, Align};
+use gtk::{
+    subclass::prelude::*, Align, CompositeTemplate, Grid, Label, LayoutChild, Orientation,
+    TemplateChild,
+};
 use std::{cell::Cell, cell::RefCell, rc::Rc, sync::Arc, sync::Mutex, sync::MutexGuard};
 
 // Modules
@@ -381,7 +384,12 @@ impl GpuPage {
         // !!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!
 
         // Get stored UUID
-        let uuid: String = self.uuid.clone().get().expect("`uuid` wasn't set properly..").to_string();
+        let uuid: String = self
+            .uuid
+            .clone()
+            .get()
+            .expect("`uuid` wasn't set properly..")
+            .to_string();
 
         // Load refresh time (s) from settings
         let refresh_rate: u32 = self.get_setting::<i32>("refreshrate") as u32;
@@ -396,9 +404,13 @@ impl GpuPage {
         let uuid_store: Arc<Mutex<String>> = Arc::new(Mutex::new(uuid));
 
         // Create thread safe container for provider
-        let provider: Option<Provider> = self.provider.clone().get().expect("`provider` wasn't set properly..").to_owned();
-        let provider_store: Arc<Mutex<Option<Provider>>> =
-            Arc::new(Mutex::new(provider));
+        let provider: Option<Provider> = self
+            .provider
+            .clone()
+            .get()
+            .expect("`provider` wasn't set properly..")
+            .to_owned();
+        let provider_store: Arc<Mutex<Option<Provider>>> = Arc::new(Mutex::new(provider));
 
         // Async fill the labels
         let id: SourceId = glib::timeout_add_seconds_local(refresh_rate, move || {
@@ -497,7 +509,12 @@ impl GpuPage {
         // println!("items saved: `{:?}`", loaded_properties_data); //TEST
 
         // Get stored UUID
-        let uuid: String = self.uuid.clone().get().expect("`uuid` wasn't set properly..").to_string();
+        let uuid: String = self
+            .uuid
+            .clone()
+            .get()
+            .expect("`uuid` wasn't set properly..")
+            .to_string();
 
         // If present in saved settings, use! otherwise follow below defaults
         if let 0 = loaded_properties_data.len() {

--- a/src/gpu_page/mod.rs
+++ b/src/gpu_page/mod.rs
@@ -26,7 +26,7 @@ use adwaita::{gio, glib, Application, ViewStack};
 use gio::Settings;
 use glib::{clone, closure, Object};
 use gtk::{prelude::*, subclass::prelude::*, Align, Button, Grid, Label, LayoutChild, Orientation};
-use std::{cell::RefMut};
+use std::cell::RefMut;
 
 // Modules
 use crate::{modificationwindow::ModificationWindow, provider::Provider, APP_ID};
@@ -338,7 +338,8 @@ impl GpuPage {
             for index in 0..loaded_views.len() {
                 // println!("VIEW {}", index);
                 // Grab all saved properties
-                let properties: Vec<String> = self.imp().check_properties_for_view(&loaded_views[index]);
+                let properties: Vec<String> =
+                    self.imp().check_properties_for_view(&loaded_views[index]);
 
                 // println!("GOT {} PROPERTIES FOR VIEW {}", properties.len(), index);
 

--- a/src/gpu_page/mod.rs
+++ b/src/gpu_page/mod.rs
@@ -24,9 +24,9 @@ use imp::ModificationWindowContainer;
 // Imports
 use adwaita::{gio, glib, Application, ViewStack};
 use gio::Settings;
-use glib::{clone, closure, translate::FromGlib, Object, SourceId};
+use glib::{clone, closure, Object};
 use gtk::{prelude::*, subclass::prelude::*, Align, Button, Grid, Label, LayoutChild, Orientation};
-use std::{cell::RefMut, sync::Arc, sync::Mutex, sync::MutexGuard};
+use std::{cell::RefMut};
 
 // Modules
 use crate::{modificationwindow::ModificationWindow, provider::Provider, APP_ID};
@@ -72,6 +72,7 @@ impl GpuPage {
      *
      */
     pub fn new(uuid: &str, name: &str, provider: Provider) -> Self {
+        // Create new page
         let obj: GpuPage = Object::new(&[]).expect("Failed to create `GpuPage`.");
 
         // Set custom properties
@@ -83,6 +84,7 @@ impl GpuPage {
         obj.setup_settings();
         obj.setup_widgets();
 
+        // Return final object
         obj
     }
 
@@ -336,7 +338,7 @@ impl GpuPage {
             for index in 0..loaded_views.len() {
                 // println!("VIEW {}", index);
                 // Grab all saved properties
-                let properties: Vec<String> = self.check_properties_for_view(&loaded_views[index]);
+                let properties: Vec<String> = self.imp().check_properties_for_view(&loaded_views[index]);
 
                 // println!("GOT {} PROPERTIES FOR VIEW {}", properties.len(), index);
 
@@ -363,7 +365,7 @@ impl GpuPage {
 
                 // Populate view given list of properties
                 let output: (Grid, Vec<Label>) =
-                    self.create_properties(new_grid, properties, labels);
+                    self.imp().create_properties(new_grid, properties, labels);
                 let new_view_grid: Grid = output.0;
                 labels = output.1;
 
@@ -560,7 +562,7 @@ impl GpuPage {
 
             // if properties exist, call create_updater() function to add time-delayed callback to update appropriate labels
             if props.len() > 0 {
-                self.create_updater(labels, props);
+                self.imp().create_updater(labels, props);
             } // else {
               //     println!("No properties, no callbacks!");
               // }
@@ -568,395 +570,6 @@ impl GpuPage {
             // Replace current view stack
             self.imp().replace_stack(Some(&new_stack));
         }
-    }
-
-    /**
-     * Name:
-     * check_properties_for_view
-     *
-     * Description:
-     * Using passed view title, returns list of saved properties
-     *
-     * Made:
-     * 03/12/2022
-     *
-     * Made by:
-     * Deren Vural
-     *
-     * Notes:
-     *
-     */
-    fn check_properties_for_view(&self, view_name: &str) -> Vec<String> {
-        // Get reference to settings object
-        let settings_obj: &Settings = self.settings();
-
-        // Load list of Properties for current Page
-        let loaded_properties_data: Vec<String> =
-            settings_obj.get::<Vec<String>>("viewcomponentconfigs");
-        println!("items saved #: `{}`", loaded_properties_data.len()); //TEST
-        println!("items saved: `{:?}`", loaded_properties_data); //TEST
-
-        // If present in saved settings, use! otherwise follow below defaults
-        if let 0 = loaded_properties_data.len() {
-            // println!("no properties.."); //TEST
-
-            vec![]
-        } else {
-            // Create temporary structure for sorting loaded data
-            let mut loaded_properties: Vec<String> =
-                vec![String::from(""); loaded_properties_data.len()];
-
-            for index in 0..loaded_properties_data.len() {
-                println!("item: `{}`", loaded_properties_data[index]); //TEST
-
-                // Split current item into the 4 parts
-                let parts: Vec<&str> = loaded_properties_data[index]
-                    .split(':')
-                    .collect::<Vec<&str>>();
-
-                // Catch any malformed items
-                if parts.len() != 4 {
-                    panic!("Malformed gschema data..");
-                }
-
-                // If from valid page
-                if parts[0] == self.property::<String>("uuid") {
-                    println!("VALID UUID"); //TEST
-
-                    // If from valid view
-                    if parts[1] == view_name {
-                        println!("VALID VIEW #"); //TEST
-
-                        // If a valid position
-                        match parts[2].parse::<usize>() {
-                            Ok(position) => {
-                                println!("POSITION INDEX: `{}`", position); //TEST
-                                if position <= loaded_properties_data.len() {
-                                    println!("VALID POSITION INDEX"); //TEST
-                                    println!("VALID PROPERTY: `{}`", parts[3]); //TEST
-
-                                    // Add to final list
-                                    loaded_properties[position] = parts[3].to_owned();
-                                }
-                            }
-                            Err(_) => panic!("Invalid Property position in gschema data.."),
-                        }
-                    }
-                }
-            }
-
-            // Remove any empty properties
-            loaded_properties.retain(|x| *x != "");
-
-            // Return final list
-            loaded_properties.to_owned()
-        }
-    }
-
-    /**
-     * Name:
-     * create_properties
-     *
-     * Description:
-     * Add labels (of properties) to a passed grid, returns the grid afterwards
-     *
-     * Made:
-     * 03/12/2022
-     *
-     * Made by:
-     * Deren Vural
-     *
-     * Notes:
-     *
-     */
-    fn create_properties(
-        &self,
-        grid: Grid,
-        properties: Vec<String>,
-        mut labels: Vec<Label>,
-    ) -> (Grid, Vec<Label>) {
-        // Load properties from struct
-        let properties_store: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(properties));
-
-        // Grab grid manager
-        let grid_manager = grid.layout_manager().unwrap();
-
-        // For each Property
-        for property in Arc::clone(&properties_store).lock().unwrap().iter() {
-            // println!("BUILDING PROPERTY LABEL: `{}`", property); //TEST
-
-            //==BUILD==
-            // Build grid for 2 labels and attach to this page
-            let new_grid_name: String = String::from("property_item_grid");
-            let new_grid: Grid = Grid::builder()
-                .name(&new_grid_name)
-                .orientation(Orientation::Horizontal)
-                //.margin_start(12)
-                //.margin_end(12)
-                //.margin_top(12)
-                //.margin_bottom(12)
-                //.halign(Align::Start)
-                //.valign(Align::Center)
-                //.hexpand(true)
-                //.vexpand(true)
-                .build();
-            grid.attach(&new_grid, 0, labels.len() as i32, 100, 12);
-
-            // Set layout properties of grid
-            let child_manager: LayoutChild = grid_manager.layout_child(&new_grid);
-            child_manager.set_property("row-span", 1);
-            child_manager.set_property("column-span", 1);
-            //child_manager.set_property("outline-style", "solid");
-            //child_manager.set_property("outline-width", 1);
-            //child_manager.set_property("border-radius", 3);
-
-            // Fetch layout manager for this (grid) child
-            match new_grid.layout_manager() {
-                Some(internal_grid_manager) => {
-                    // Decide on title label size
-                    let space: i32;
-                    let pretty_label: &str;
-                    //TODO: Update to use global list
-                    match property.to_owned().as_str() {
-                        "util" => {
-                            pretty_label = "GPU Utilization";
-                            space = 5
-                        }
-                        "mem_ctrl_util" => {
-                            pretty_label = "Memory Controller Utilization";
-                            space = 5
-                        }
-                        "encoder_util" => {
-                            pretty_label = "Encoder Utilization";
-                            space = 5
-                        }
-                        "decoder_util" => {
-                            pretty_label = "Decoder Utilization";
-                            space = 5
-                        }
-                        "fan_speed" => {
-                            pretty_label = "Fan Speed";
-                            space = 5
-                        }
-                        "temp" => {
-                            pretty_label = "Temperature";
-                            space = 5
-                        }
-                        "memory_usage" => {
-                            pretty_label = "Memory Usage";
-                            space = 8
-                        }
-                        "memory_total" => {
-                            pretty_label = "Memory Total";
-                            space = 8
-                        }
-                        "power_usage" => {
-                            pretty_label = "Power Usage";
-                            space = 8
-                        }
-                        "none" => {
-                            pretty_label = "None";
-                            space = 5
-                        }
-                        _ => {
-                            pretty_label = property;
-                            space = 5
-                        }
-                    }
-
-                    // Build title label & add to grid
-                    let new_title: String = String::from(property.to_owned()) + "_label";
-                    let new_title_label: Label = Label::builder()
-                        .label(pretty_label)
-                        .name(&new_title)
-                        .hexpand(true)
-                        .hexpand_set(true)
-                        //.halign(Align::Center)
-                        .halign(Align::Start)
-                        //.valign(Align::Center)
-                        .margin_top(12)
-                        .margin_bottom(12)
-                        .width_chars(space)
-                        .build();
-                    new_grid.attach(&new_title_label, 0, 0, 1, 1);
-
-                    // Set layout properties of (title label) child
-                    let title_manager: LayoutChild =
-                        internal_grid_manager.layout_child(&new_title_label);
-                    title_manager.set_property("row-span", 1);
-                    title_manager.set_property("column-span", 1);
-
-                    // Decide on content label size
-                    let space: i32;
-                    match property.to_owned().as_str() {
-                        "util" | "fan_speed" | "temp" | "none" => space = 5,
-                        "memory_usage" | "memory_total" => space = 8,
-                        _ => space = 5,
-                    }
-
-                    // Build content label & add to grid
-                    let new_content: String = String::from(property.to_owned());
-                    let new_content_label: Label = Label::builder()
-                        .label("")
-                        .name(&new_content)
-                        .halign(Align::End)
-                        //.valign(Align::Center)
-                        .width_chars(space)
-                        .build();
-                    new_grid.attach(&new_content_label, 1, 0, 1, 1);
-
-                    // Set layout properties of (content label) child
-                    let content_manager: LayoutChild =
-                        internal_grid_manager.layout_child(&new_content_label);
-                    content_manager.set_property("row-span", 1);
-                    title_manager.set_property("column-span", 1);
-
-                    // Add to list of content labels, for updating in closure (see below)
-                    labels.push(new_content_label);
-                }
-                None => panic!("Cannot find layout manager.."),
-            }
-        }
-
-        // for lab in &labels {
-        //     println!("LABEL: `{}`", lab.widget_name());
-        // }
-
-        // Return modified grid object
-        (grid, labels)
-    }
-
-    /**
-     * Name:
-     * create_updater
-     *
-     * Description:
-     * Creates a recurring closure to fill the passed list of labels
-     * Stores the ID of the recurring closure to allow removal
-     *
-     * Made:
-     * 04/12/2022
-     *
-     * Made by:
-     * Deren Vural
-     *
-     * Notes:
-     * <https://stackoverflow.com/questions/70986004/gtk-rs-set-label-within-glibtimeout-add>
-     * <https://doc.rust-lang.org/rust-by-example/fn/closures/input_parameters.html>
-     *
-     * !!UNSAFE CODE HERE!!
-     */
-    fn create_updater(&self, labels: Vec<Label>, properties: Vec<String>) {
-        // !!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!
-        // Check for any running recurring closures
-        // Grab stored ID
-        let id_raw: u32 = self.property("refreshid");
-        unsafe {
-            // If the stored ID is valid
-            if id_raw != 0 {
-                // Re-translate to SourceId object
-                let id: SourceId = FromGlib::from_glib(id_raw);
-
-                // Remove recurring closure
-                id.remove();
-
-                // println!("REMOVED RECURRING CLOSURE.."); //TEST
-            } else {
-                // println!("NO PRE-EXISTING RECURRING CLOSURE.."); //TEST
-            }
-        }
-        // !!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!
-
-        // Get reference to settings object
-        let settings_obj: &Settings = self.settings();
-
-        // Load refresh time (s) from settings
-        let refresh_rate: u32 = settings_obj.get::<i32>("refreshrate") as u32;
-
-        // Create thread safe container for properties
-        let properties_store: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(properties));
-
-        // Create thread safe container for labels
-        let label_store: Arc<Mutex<Vec<Label>>> = Arc::new(Mutex::new(labels));
-
-        // Create thread safe container for uuid, needed for processor
-        let uuid_store: Arc<Mutex<String>> = Arc::new(Mutex::new(self.property("uuid")));
-
-        // Create thread safe container for provider
-        let provider_store: Arc<Mutex<Option<Provider>>> =
-            Arc::new(Mutex::new(self.property("provider")));
-
-        // Async fill the labels
-        let id: SourceId = glib::timeout_add_seconds_local(refresh_rate, move || {
-            // Grab locked data
-            // list of Properties
-            let properties_lock: Arc<Mutex<Vec<String>>> = Arc::clone(&properties_store);
-            let properties: MutexGuard<Vec<String>> = properties_lock.lock().unwrap();
-            // uuid
-            let uuid_lock: Arc<Mutex<String>> = Arc::clone(&uuid_store);
-            let uuid: String = uuid_lock.lock().unwrap().as_str().to_owned();
-            // current provider for scanning gpu data
-            let provider_lock: Arc<Mutex<Option<Provider>>> = Arc::clone(&provider_store);
-            let mut provider_container: MutexGuard<Option<Provider>> =
-                provider_lock.lock().unwrap();
-
-            let labels_lock: Arc<Mutex<Vec<Label>>> = Arc::clone(&label_store);
-            let labels_container: MutexGuard<Vec<Label>> = labels_lock.lock().unwrap();
-            // println!("labels: `{}`", labels_container.len());
-
-            // For each Property
-            match &mut *provider_container {
-                Some(current_provider) => {
-                    for property in properties.iter() {
-                        // println!("property: `{}`", property); //TEST
-
-                        if property == "none" {
-                            // Check if correct label
-                            for label in labels_container.iter() {
-                                if *property.to_owned() == label.widget_name() {
-                                    label.set_label("N/A");
-                                    // no break here - could be duplicates
-                                }
-                            }
-                        } else {
-                            // Grab current Property from provider
-                            match current_provider.get_gpu_data(&uuid, property) {
-                                Ok(property_value) => {
-                                    // For each output label of the page
-                                    for label in labels_container.iter() {
-                                        // println!("COMPARING AGAINST 1: `{}`", property);
-                                        // println!("COMPARING AGAINST 2: `{}`", label.widget_name());
-
-                                        // Check if correct label
-                                        if *property.to_owned() == label.widget_name() {
-                                            label.set_label(&property_value);
-                                            // no break here - could be duplicates
-                                        }
-                                    }
-                                }
-                                Err(err) => {
-                                    println!("panicked when fetching gpu data: `{}`", err);
-                                    return Continue(false);
-                                }
-                            }
-                        }
-                    }
-                }
-                None => {
-                    println!("panicked when fetching current provider..");
-                    return Continue(false);
-                }
-            }
-
-            Continue(true)
-        });
-
-        // !!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!
-        // Save ID of recurring closure
-        unsafe {
-            self.set_property("refreshid", id.as_raw());
-        }
-        // !!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!!!UNSAFE CODE HERE!!
     }
 
     /**

--- a/src/mainwindow/imp.rs
+++ b/src/mainwindow/imp.rs
@@ -22,7 +22,8 @@ use adwaita::{gio, glib, prelude::*, subclass::prelude::*};
 use gio::Settings;
 use glib::{
     once_cell::sync::Lazy, once_cell::sync::OnceCell, signal::Inhibit,
-    subclass::InitializingObject, FromVariant, ParamSpec, Value, subclass::Signal, subclass::SignalType,
+    subclass::InitializingObject, subclass::Signal, subclass::SignalType, FromVariant, ParamSpec,
+    Value,
 };
 use gtk::{
     subclass::prelude::*, Button, CompositeTemplate, PolicyType, ScrolledWindow, Stack,

--- a/src/mainwindow/imp.rs
+++ b/src/mainwindow/imp.rs
@@ -22,7 +22,7 @@ use adwaita::{gio, glib, prelude::*, subclass::prelude::*};
 use gio::Settings;
 use glib::{
     once_cell::sync::Lazy, once_cell::sync::OnceCell, signal::Inhibit,
-    subclass::InitializingObject, FromVariant, ParamSpec, Value,
+    subclass::InitializingObject, FromVariant, ParamSpec, Value, subclass::Signal, subclass::SignalType,
 };
 use gtk::{
     subclass::prelude::*, Button, CompositeTemplate, PolicyType, ScrolledWindow, Stack,
@@ -53,12 +53,15 @@ enum TemperatureUnit {
 #[derive(CompositeTemplate, Default)]
 #[template(resource = "/main-window.ui")]
 pub struct MainWindow {
+    // Public
     pub settings: OnceCell<Settings>,
     pub settings_window: Rc<RefCell<SettingsWindowContainer>>,
     pub provider: Cell<Option<Provider>>,
 
+    // Private
     gpu_pages: RefCell<Vec<GpuPage>>,
 
+    // Template Children
     #[template_child]
     pub gpu_stack: TemplateChild<Stack>,
 }
@@ -1344,32 +1347,13 @@ impl MainWindow {
             }
         }
     }
-}
 
-/**
- * Name:
- * MainWindow
- *
- * Description:
- * Trait defining template callbacks shared by all MainWindow objects
- *
- * Made:
- * 13/10/2022
- *
- * Made by:
- * Deren Vural
- *
- * Notes:
- *
- */
-#[gtk::template_callbacks]
-impl MainWindow {
     /**
      * Name:
      * refresh_cards
      *
      * Description:
-     * Template callback for GPU list refresh button
+     * Re-create the GpuPages and stack contents when called
      *
      * Made:
      * 28/10/2022
@@ -1380,10 +1364,7 @@ impl MainWindow {
      * Notes:
      *
      */
-    #[template_callback]
-    fn refresh_cards(&self, _button: &Button) {
-        // println!("GPU Scan Button Pressed!"); //TEST
-
+    pub fn refresh_cards(&self) {
         // Clear current ActionRow objects from GtkListBox
         let mut done: bool = false;
         while !done {
@@ -1544,58 +1525,47 @@ impl MainWindow {
                 }
             }
         }
+    }
+}
 
-        /*
-        // Load refresh time (s) from settings
-        let refresh_rate: u32 = self.get_setting::<i32>("refreshrate") as u32;
-
-        // Create thread safe container for provider
-        // Grab copy of current provider
-        let provider_container: Option<Provider> = self.provider.take();
-        self.provider.set(provider_container.clone());
-        let provider_store: Arc<Mutex<Option<Provider>>> = Arc::new(Mutex::new(provider_container));
-
-        // Wrapper around `NonNull<RawType>` that just implements `Send`
-        struct WrappedPointer(Settings);
-        unsafe impl Send for WrappedPointer {}
-        // Safe wrapper around `WrappedPointer` that gives access to the pointer
-        // only with the mutex locked.
-        struct SafeType {
-            inner: Mutex<WrappedPointer>,
-        }
-        let settings_store: SafeType = SafeType
-        {
-            inner: Mutex::new(WrappedPointer(self.settings.get().expect("").to_owned()))
-        };
-
-        // Async check for provider changes
-        //glib::timeout_add_seconds(refresh_rate, clone!(@strong self as window => move || {
-        //glib::timeout_add_seconds(refresh_rate, clone!(@strong settings_store as window => move || {
-        glib::timeout_add_seconds_local(refresh_rate, move || {
-            // Grab locked data
-            // settings object
-            let settings_container: MutexGuard<WrappedPointer> = settings_store.inner.lock().unwrap();
-            // current provider for scanning gpu data
-            let provider_lock: Arc<Mutex<Option<Provider>>> = Arc::clone(&provider_store);
-            let mut provider_container: MutexGuard<Option<Provider>> = provider_lock.lock().unwrap();
-
-
-            // Check provider type in settings
-            let provider_type: i32 = settings_container.0.get("provider");
-
-            // If type has been changed, update provider
-            match &mut *provider_container {
-                Some(prov) => {
-                    if prov.property::<i32>("provider_type") != provider_type {
-                        //
-                    }
-                }
-                None => todo!(),
-            }
-
-            Continue(true)
-        });
-        */
+/**
+ * Name:
+ * MainWindow
+ *
+ * Description:
+ * Trait defining template callbacks shared by all MainWindow objects
+ *
+ * Made:
+ * 13/10/2022
+ *
+ * Made by:
+ * Deren Vural
+ *
+ * Notes:
+ *
+ */
+#[gtk::template_callbacks]
+impl MainWindow {
+    /**
+     * Name:
+     * refresh_cards
+     *
+     * Description:
+     * Template callback for GPU list refresh button
+     *
+     * Made:
+     * 28/10/2022
+     *
+     * Made by:
+     * Deren Vural
+     *
+     * Notes:
+     *
+     */
+    #[template_callback]
+    fn refresh_cards_clicked(&self, _button: &Button) {
+        // println!("GPU Scan Button Pressed!"); //TEST
+        self.refresh_cards();
     }
 }
 
@@ -1739,6 +1709,38 @@ impl ObjectImpl for MainWindow {
             }
             _ => panic!("Property `{}` does not exist..", pspec.name()),
         }
+    }
+
+    /**
+     * Name:
+     * signals
+     *
+     * Description:
+     * Defines the list of signals
+     *
+     * Made:
+     * 10/01/2023
+     *
+     * Made by:
+     * Deren Vural
+     *
+     * Notes:
+     * beware that you need to use kebab-case (<https://en.wikipedia.org/wiki/Letter_case#Kebab_case>)
+     *
+     * <https://gtk-rs.org/gtk4-rs/stable/latest/book/g_object_signals.html>
+     *
+     * SignalType::from(i32::static_type())
+     */
+    fn signals() -> &'static [Signal] {
+        static SIGNALS: Lazy<Vec<Signal>> = Lazy::new(|| {
+            vec![Signal::builder(
+                "update-all-views",
+                &[],
+                SignalType::from(i32::static_type()),
+            )
+            .build()]
+        });
+        SIGNALS.as_ref()
     }
 }
 

--- a/src/mainwindow/mod.rs
+++ b/src/mainwindow/mod.rs
@@ -24,7 +24,7 @@ use imp::SettingsWindowContainer;
 // Imports
 use adwaita::{gio, glib, prelude::*, subclass::prelude::*};
 use gio::{Settings, SimpleAction};
-use glib::{clone, Object, closure};
+use glib::{clone, closure, Object};
 use std::cell::RefMut;
 
 // Modules

--- a/src/mainwindow/mod.rs
+++ b/src/mainwindow/mod.rs
@@ -24,7 +24,7 @@ use imp::SettingsWindowContainer;
 // Imports
 use adwaita::{gio, glib, prelude::*, subclass::prelude::*};
 use gio::{Settings, SimpleAction};
-use glib::{clone, Object};
+use glib::{clone, Object, closure};
 use std::cell::RefMut;
 
 // Modules
@@ -72,6 +72,7 @@ impl MainWindow {
      *
      */
     pub fn new(app: &adwaita::Application) -> Self {
+        // Create new window
         Object::new(&[("application", app)]).expect("`MainWindow` should be  instantiable.")
     }
 
@@ -139,7 +140,23 @@ impl MainWindow {
      *
      */
     fn setup_widgets(&self) {
-        //
+        // Connect closure to re-load stored views (with different settings) when a settings window is closed
+        //NOTE: expected return value seems to be broken - look at imp.rs:1772
+        self.connect_closure(
+            "update-all-views",
+            false,
+            closure!(move |window: MainWindow| {
+                println!("closure called!"); //TEST
+
+                // Reload views
+                println!("reloading views.."); //TEST
+                window.imp().refresh_cards();
+                println!("views reloaded.."); //TEST
+
+                // Return final value
+                0
+            }),
+        );
     }
 
     /**
@@ -339,7 +356,7 @@ impl MainWindow {
                             let app: adwaita::Application = adwaita::Application::builder().application_id(APP_ID).build();
 
                             // Create new settings window
-                            let new_settings_window: SettingsWindow = SettingsWindow::new(&app);
+                            let new_settings_window: SettingsWindow = SettingsWindow::new(&app, &window);
 
                             // Show new settings window
                             new_settings_window.show();
@@ -361,7 +378,7 @@ impl MainWindow {
                     let app: adwaita::Application = adwaita::Application::builder().application_id(APP_ID).build();
 
                     // Create settings window
-                    let new_settings_window: SettingsWindow = SettingsWindow::new(&app);
+                    let new_settings_window: SettingsWindow = SettingsWindow::new(&app, &window);
 
                     // Show new settings window
                     new_settings_window.show();

--- a/src/modificationwindow/mod.rs
+++ b/src/modificationwindow/mod.rs
@@ -80,6 +80,7 @@ impl ModificationWindow {
         uuid: &str,
         parent_window: &GpuPage,
     ) -> Self {
+        // Create new window
         let obj: ModificationWindow = Object::new(&[("application", app)])
             .expect("`ModificationWindow` should be  instantiable.");
 
@@ -99,6 +100,7 @@ impl ModificationWindow {
         obj.setup_settings();
         obj.setup_widgets();
 
+        // Return final object
         obj
     }
 
@@ -387,7 +389,7 @@ impl ModificationWindow {
                 window.imp().update_stored_data();
                 // println!("CHANGES APPLIED.."); //TEST
 
-                // TODO: Emit signal to notify changes made to view (and thus reload required)
+                // Emit signal to notify changes made to view (and thus reload required)
                 let modification_window_container: RefMut<ParentContainer> = window.imp().parent_window.borrow_mut();
                 let _result = modification_window_container.window.as_ref().unwrap().emit_by_name::<i32>("update-views", &[&window.property::<i32>("new-view-id")]);
 
@@ -417,7 +419,7 @@ impl ModificationWindow {
                     window.imp().delete_stored_data();
                     // println!("VIEW DELETED.."); //TEST
 
-                    // TODO: Emit signal to notify changes made to view (and thus reload required)
+                    // Emit signal to notify changes made to view (and thus reload required)
                     let modification_window_container: RefMut<ParentContainer> = window.imp().parent_window.borrow_mut();
                     let _result = modification_window_container.window.as_ref().unwrap().emit_by_name::<i32>("update-views", &[&(-1).to_value()]);
 

--- a/src/resources/main-window.ui
+++ b/src/resources/main-window.ui
@@ -43,7 +43,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
             <property name="tooltip-text" translatable="yes">Scan for GPUs</property>
 
             <!-- Signals -->
-            <signal name="clicked" handler="refresh_cards" swapped="true"/>
+            <signal name="clicked" handler="refresh_cards_clicked" swapped="true"/>
           </object>
         </child>
       </object>

--- a/src/settingswindow/imp.rs
+++ b/src/settingswindow/imp.rs
@@ -381,8 +381,13 @@ impl WindowImpl for SettingsWindow {
         self.update_setting("app-settings-open", false);
 
         // Emit signal to notify changes made to view (and thus reload required)
-        let modification_window_container: RefMut<ParentContainer> = self.parent_window.borrow_mut();
-        let _result = modification_window_container.window.as_ref().unwrap().emit_by_name::<i32>("update-all-views", &[]);
+        let modification_window_container: RefMut<ParentContainer> =
+            self.parent_window.borrow_mut();
+        let _result = modification_window_container
+            .window
+            .as_ref()
+            .unwrap()
+            .emit_by_name::<i32>("update-all-views", &[]);
 
         // Pass close request on to the parent
         self.parent_close_request(window)

--- a/src/settingswindow/imp.rs
+++ b/src/settingswindow/imp.rs
@@ -23,15 +23,27 @@ use gio::Settings;
 use glib::{once_cell::sync::Lazy, ParamSpec, Value};
 use glib::{once_cell::sync::OnceCell, signal::Inhibit, subclass::InitializingObject};
 use gtk::{subclass::prelude::*, CheckButton, CompositeTemplate, SpinButton, TemplateChild};
+use std::{cell::RefCell, cell::RefMut, rc::Rc};
 
 // Modules
 //use crate::utils::data_path;
+use crate::mainwindow::MainWindow;
+
+/// Structure for storing a SettingsWindow object and any related information
+#[derive(Default)]
+pub struct ParentContainer {
+    pub window: Option<MainWindow>,
+}
 
 /// Object holding the State and any Template Children
 #[derive(CompositeTemplate, Default)]
 #[template(resource = "/settings-window.ui")]
 pub struct SettingsWindow {
+    // Public
     pub settings: OnceCell<Settings>,
+    pub parent_window: Rc<RefCell<ParentContainer>>,
+
+    // Template Children
     #[template_child]
     pub refreshrate_input: TemplateChild<SpinButton>,
     #[template_child]
@@ -367,6 +379,10 @@ impl WindowImpl for SettingsWindow {
 
         // Store state in settings
         self.update_setting("app-settings-open", false);
+
+        // Emit signal to notify changes made to view (and thus reload required)
+        let modification_window_container: RefMut<ParentContainer> = self.parent_window.borrow_mut();
+        let _result = modification_window_container.window.as_ref().unwrap().emit_by_name::<i32>("update-all-views", &[]);
 
         // Pass close request on to the parent
         self.parent_close_request(window)

--- a/src/settingswindow/mod.rs
+++ b/src/settingswindow/mod.rs
@@ -25,9 +25,10 @@ use adwaita::{gio, glib, prelude::*, subclass::prelude::*};
 use gio::Settings;
 use glib::{clone, Object};
 use gtk::{Adjustment, CheckButton, StringList};
+use std::cell::RefMut;
 
 // Modules
-use crate::APP_ID;
+use crate::{mainwindow::MainWindow, settingswindow::imp::ParentContainer, APP_ID};
 
 // GObject wrapper for Property
 glib::wrapper! {
@@ -70,9 +71,28 @@ impl SettingsWindow {
      * Notes:
      *
      */
-    pub fn new(app: &adwaita::Application) -> Self {
+    pub fn new(
+        app: &adwaita::Application,
+        parent_window: &MainWindow,
+    ) -> Self {
         // Create new window
-        Object::new(&[("application", app)]).expect("`SettingsWindow` should be  instantiable.")
+        let obj: SettingsWindow = Object::new(&[("application", app)]).expect("`SettingsWindow` should be  instantiable.");
+
+        // Set custom properties
+        //
+
+        // Set ref to parent
+        {
+            let mut modification_window_container: RefMut<ParentContainer> =
+                obj.imp().parent_window.borrow_mut();
+            modification_window_container.window = Some(parent_window.to_owned());
+        }
+
+        // Apply any setup actions that need the above properties
+        //
+
+        // Return final object
+        obj
     }
 
     /**

--- a/src/settingswindow/mod.rs
+++ b/src/settingswindow/mod.rs
@@ -71,12 +71,10 @@ impl SettingsWindow {
      * Notes:
      *
      */
-    pub fn new(
-        app: &adwaita::Application,
-        parent_window: &MainWindow,
-    ) -> Self {
+    pub fn new(app: &adwaita::Application, parent_window: &MainWindow) -> Self {
         // Create new window
-        let obj: SettingsWindow = Object::new(&[("application", app)]).expect("`SettingsWindow` should be  instantiable.");
+        let obj: SettingsWindow = Object::new(&[("application", app)])
+            .expect("`SettingsWindow` should be  instantiable.");
 
         // Set custom properties
         //


### PR DESCRIPTION
Check if provider changed on settingswindow exit
Added custom signal handling in to handle this. Also moved *lots* of GpuPage functionality to imp()
Closes #32 

Updated MainWindow UI:
- Renamed refresh button callback from "refresh_cards" to "refresh_cards_clicked"

Updated MainWindow class:
- Added a "update-all-views" signal with a new "signals()" function
- Added some better struct definition comments
- Split "refresh_cards()" function into two functions, one a pub function in MainWindow impl (so can be called by other functions) and "refresh_cards_clicked()" template callback
- Removed commented code from end of "refresh_cards()" function
- Added some better constructor comments
- Connected a closure to run on "update-all-views" signal, calls "refresh_cards()" function
- Updated SettingsWindow creation to pass self reference

Updated SettingsWindow class:
- Added a "ParentContainer" struct like in ModificationWindow class, functions pretty much the same
- Signal ("update-all-views") emission called from "close_request()" function instead
- Added some better constructor comments
- Added some better struct definition comments
- Updated constructor to handle new "ParentContainer" reference object

Updated GpuPage class:
- Moved "create_properties()" function to imp(), modified accordingly
- Moved "create_updater()" function to imp(), modified accordingly
- Moved "check_properties_for_view()" function to imp(), modified accordingly
- Added some better constructor comments
- Added some better struct definition comments
- Updated "load_views()" function to handle moved functions

Updated ModificationWindow class:
- Added some better struct definition comments
- Added some better constructor comments
- Removed some completed "TODO" comments